### PR TITLE
Update schema.sql file to include 3 other tables: questions, contributors, and responses

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,23 @@
+CREATE TABLE surveys(
+   id serial PRIMARY KEY,
+   name text NOT NULL
+ );
+                                                        
+ CREATE TABLE questions(
+  id serial PRIMARY KEY,
+  survey_id int REFERENCES surveys(id) ON DELETE CASCADE NOT NULL,
+  text text NOT NULL
+);
+
+ CREATE TABLE contributors(
+   id serial PRIMARY KEY,
+   email_address text UNIQUE NOT NULL
+ );
+
+ CREATE TABLE responses(
+   id serial PRIMARY KEY,
+   question_id int REFERENCES questions(id) NOT NULL,
+   contributor_id int REFERENCES contributors(id) NOT NULL,
+   text text NOT NULL,
+   submitted_on timestamp DEFAULT NOW()
+ );


### PR DESCRIPTION
Hi Lucas, 

Take a look at this schema and let me know what you think; it should be implementing what we discussed last Saturday.

I set up ON DELETE CASCADE, but I'm wondering if maybe we want to change this up so that the surveys table has an additional field: whether or not that survey is currently active? That way we could archive older data and still have a check to ensure we're not taking responses to deprecated surveys.

Also, naming fields text probably isn't the best practice, but I wasn't sure what else to use for those two since questions.question and responses.response seemed weird to me. What do you think, any ideas?