### PR TITLE
Add updated schema with choices table; update responses table

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1,9 +1,10 @@
+CREATE EXTENSION IF NOT EXISTS citext;
+
 CREATE TABLE surveys(
    id serial PRIMARY KEY,
    name text NOT NULL,
    active boolean DEFAULT false
- );
-                                                        
+ );                                                        
  CREATE TABLE questions(
   id serial PRIMARY KEY,
   survey_id int REFERENCES surveys(id) NOT NULL,
@@ -15,10 +16,18 @@ CREATE TABLE surveys(
    email_address text UNIQUE NOT NULL
  );
 
- CREATE TABLE responses(
+CREATE TABLE choices(
+  id serial PRIMARY KEY,
+  question_id int REFERENCES questions(id) NOT NULL,
+  choice citext NOT NULL, 
+  UNIQUE (question_id, choice)
+);
+ 
+CREATE TABLE responses(
    id serial PRIMARY KEY,
-   question_id int REFERENCES questions(id) NOT NULL,
+   choices_id int REFERENCES choices(id) NOT NULL,
    contributor_id int REFERENCES contributors(id) NOT NULL,
-   response text NOT NULL,
-   submitted_on timestamp DEFAULT NOW()
+   survey_id int REFERENCES surveys(id),
+   submitted_on timestamp DEFAULT NOW(),
+   UNIQUE (choices_id, contributor_id)
  );


### PR DESCRIPTION
This commit adds a table to contain choices for survey questions and updates the responses table to include a column for the choice chosen.

Choices relate to specific questions (1:M question->choices) and the responses table relates to surveys, choices, and contributors.

Note that before adding new responses to the responses table, a SELECT and possible DELETE should be run if the current contributor_id already has responses in the table for the current survey_id.

LUCAS: Can you please take a look at this updated schema and let me know what you think? I figure we don't have to have questions related to the responses table and can join them using the choices table if need be, but perhaps there's a better way to go about it.